### PR TITLE
ShareItem command (share items in chat or privately)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.crashdemons</groupId>
     <artifactId>DisplayItem-Spigot</artifactId>
-    <version>2.7.1-SNAPSHOT</version>
+    <version>2.8.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>

--- a/src/main/java/com/github/crashdemons/displayitem_spigot/ChatLineFormatter.java
+++ b/src/main/java/com/github/crashdemons/displayitem_spigot/ChatLineFormatter.java
@@ -14,6 +14,8 @@ import org.bukkit.entity.Player;
  * @author crashdemons (crashenator at gmail.com)
  */
 public class ChatLineFormatter extends MessageFormatter{
+    
+    //TODO: static?
 
     private static final String MESSAGE_REPLACEMENT_PLACEHOLDER = "[[DI-MESG-MARKER]]";
 

--- a/src/main/java/com/github/crashdemons/displayitem_spigot/ChatLineFormatter.java
+++ b/src/main/java/com/github/crashdemons/displayitem_spigot/ChatLineFormatter.java
@@ -28,9 +28,8 @@ public class ChatLineFormatter extends MessageFormatter{
         return name;
     }
     
-    private String getChatLineFormat(String bukkitChatFormat){
+    private static String getChatLineFormat(String bukkitChatFormat, boolean overrideChatLineFormat){
         String chatLineFormat;
-        boolean overrideChatLineFormat = DisplayItem.plugin.getConfig().getBoolean("displayitem.overridechatformat");
         if(overrideChatLineFormat){
             chatLineFormat = DisplayItem.plugin.getConfig().getString("displayitem.format");
         }else{
@@ -39,15 +38,15 @@ public class ChatLineFormatter extends MessageFormatter{
         return chatLineFormat;
     }
     
-    private String formatChatLine(Player player, String chatLineFormat, String message){
+    private static String formatChatLine(Player player, String chatLineFormat, String message){
         return MacroReplacements.replaceAll(player, chatLineFormat, message, "", false, -1, false);
     }
     
     
-    public SplitChatMessage chatLineInsertItem(Player player, String bukkitChatFormat, String bukkitMessageText, boolean colorize) {
+    public static SplitChatMessage chatLineInsertItem(Player player, String bukkitChatFormat, String bukkitMessageText, boolean colorize, boolean overridechatformat) {
         BaseComponent[] messageInserted = messageInsertItem(player, bukkitMessageText, colorize).toComponents();
         
-        String chatLineFormat = ChatColor.translateAlternateColorCodes('&',getChatLineFormat(bukkitChatFormat));
+        String chatLineFormat = ChatColor.translateAlternateColorCodes('&',getChatLineFormat(bukkitChatFormat,overridechatformat));
         
         String displayname = getPlayerName(player);
         //use a temporary placeholder so that we can tell if the chat format added text before and/or after the message, not just after!

--- a/src/main/java/com/github/crashdemons/displayitem_spigot/ChatLineFormatter.java
+++ b/src/main/java/com/github/crashdemons/displayitem_spigot/ChatLineFormatter.java
@@ -38,7 +38,7 @@ public class ChatLineFormatter extends MessageFormatter{
         return chatLineFormat;
     }
     
-    private static String formatChatLine(Player player, String chatLineFormat, String message){
+    public static String formatChatLine(Player player, String chatLineFormat, String message){
         return MacroReplacements.replaceAll(player, chatLineFormat, message, "", false, -1, false);
     }
     

--- a/src/main/java/com/github/crashdemons/displayitem_spigot/ChatListener.java
+++ b/src/main/java/com/github/crashdemons/displayitem_spigot/ChatListener.java
@@ -5,6 +5,7 @@
  */
 package com.github.crashdemons.displayitem_spigot;
 
+import com.github.crashdemons.displayitem_spigot.events.ChatEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.HandlerList;
@@ -44,6 +45,12 @@ public class ChatListener implements Listener {
     @Nullable
     public ChatEventExecutor getExecutor(){
         return executor;
+    }
+    
+    public boolean forceEvent(ChatEvent e){
+        if(executor==null) return false;
+        executor.onChat(e);
+        return true;
     }
     
     private void reloadPriority(){

--- a/src/main/java/com/github/crashdemons/displayitem_spigot/ChatListener.java
+++ b/src/main/java/com/github/crashdemons/displayitem_spigot/ChatListener.java
@@ -10,6 +10,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.jetbrains.annotations.Nullable;
 
 /**
  *
@@ -18,23 +19,31 @@ import org.bukkit.event.player.AsyncPlayerChatEvent;
 public class ChatListener implements Listener {
 
     EventPriority listenerpriority;
+    ChatEventExecutor executor = null;
     
     public ChatListener(){
     }
     
     public void registerEvents(){
-        Bukkit.getServer().getPluginManager().registerEvent(AsyncPlayerChatEvent.class, this, listenerpriority, new ChatEventExecutor(this,listenerpriority), DisplayItem.plugin, true);
+        executor = new ChatEventExecutor(this,listenerpriority);
+        Bukkit.getServer().getPluginManager().registerEvent(AsyncPlayerChatEvent.class, this, listenerpriority, executor, DisplayItem.plugin, true);
         DisplayItem.plugin.getLogger().info("Registered listener");
     }
     
     public void unregisterEvents(){
         HandlerList.unregisterAll(this);
+        executor=null;
         DisplayItem.plugin.getLogger().info("Unregistered listener");
     }
     
     public void reloadEvents(){
         unregisterEvents();
         registerEvents();
+    }
+    
+    @Nullable
+    public ChatEventExecutor getExecutor(){
+        return executor;
     }
     
     private void reloadPriority(){

--- a/src/main/java/com/github/crashdemons/displayitem_spigot/DisplayItem.java
+++ b/src/main/java/com/github/crashdemons/displayitem_spigot/DisplayItem.java
@@ -54,6 +54,44 @@ public class DisplayItem extends JavaPlugin{
         getLogger().info("disabled");
     }
 
+    private boolean onCommandShare(CommandSender sender, Command cmd, String label, String[] args){
+        if(args.length>1) return false;
+        if (sender.hasPermission("displayitem.share")){ 
+            sender.sendMessage(ChatColor.RED+"You don't have permission to use this command.");
+            return true;
+        }
+        
+        boolean canTarget = sender.hasPermission("displayitem.share.other");
+        boolean canPublish = sender.hasPermission("displayitem.share.all");
+        if (!canTarget && !canPublish){ 
+            sender.sendMessage(ChatColor.RED+"You don't have permission to share items with anyone.");
+            return true;
+        }
+        
+        
+        boolean hasTarget = args.length==1;
+        boolean willPublish = args.length==0;//same as !hasTarget given our preconditions
+        if(hasTarget){
+            if(!canTarget){
+                sender.sendMessage(ChatColor.RED+"You don't have permission to share items with someone, try just /shareitem.");
+                return true;
+            }
+            String targetUser = args[0];
+            //share with user
+        }
+        if(willPublish){
+            if(!canPublish){
+                sender.sendMessage(ChatColor.RED+"You don't have permission to share items with everyone, try /shareitem <user>.");
+                return true;
+            }
+            //share with everyone.
+        }
+        
+        
+        
+        
+        return true;
+    }
     
     private boolean onCommandReload(CommandSender sender, Command cmd, String label, String[] args){
         if(args.length!=0) return false;

--- a/src/main/java/com/github/crashdemons/displayitem_spigot/DisplayItem.java
+++ b/src/main/java/com/github/crashdemons/displayitem_spigot/DisplayItem.java
@@ -1,12 +1,16 @@
 package com.github.crashdemons.displayitem_spigot;
 
 import com.github.crashdemons.displayitem_spigot.calibrator.Calibrator;
+import com.github.crashdemons.displayitem_spigot.events.ShareCommandEvent;
 import com.github.crashdemons.displayitem_spigot.plugins.placeholderapi.PlaceholderSupport;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitScheduler;
 
 public class DisplayItem extends JavaPlugin{
 
@@ -54,12 +58,36 @@ public class DisplayItem extends JavaPlugin{
         getLogger().info("disabled");
     }
 
+    private void syncOperation(Runnable task, long tickDelay){
+        getServer().getScheduler().scheduleSyncDelayedTask(this, task, tickDelay);
+    }
+    
+    private void shareItem(Player sender, Player target){
+        ShareCommandEvent event;
+        if(target==null){
+            event = new ShareCommandEvent(sender);
+        }else{
+            event = new ShareCommandEvent(sender,target);
+        }
+        syncOperation(()->{
+            listener.forceEvent(event);
+        },1L);
+    }
+    
     private boolean onCommandShare(CommandSender sender, Command cmd, String label, String[] args){
         if(args.length>1) return false;
         if (sender.hasPermission("displayitem.share")){ 
             sender.sendMessage(ChatColor.RED+"You don't have permission to use this command.");
             return true;
         }
+        
+        
+        if(!(sender instanceof Player)){
+            sender.sendMessage(ChatColor.RED+"This command can only be ran by a player.");
+            return true;
+        }
+        Player player = (Player) sender;
+        
         
         boolean canTarget = sender.hasPermission("displayitem.share.other");
         boolean canPublish = sender.hasPermission("displayitem.share.all");
@@ -77,14 +105,19 @@ public class DisplayItem extends JavaPlugin{
                 return true;
             }
             String targetUser = args[0];
-            //share with user
+            Player target = Bukkit.getPlayer(targetUser);
+            if (target==null){ 
+                sender.sendMessage(ChatColor.RED+"Can't find a user with the name '"+target+"' online.");
+                return true;
+            }
+            shareItem(player,target);//share with user
         }
         if(willPublish){
             if(!canPublish){
                 sender.sendMessage(ChatColor.RED+"You don't have permission to share items with everyone, try /shareitem <user>.");
                 return true;
             }
-            //share with everyone.
+            shareItem(player,null);//share with everyone.
         }
         
         

--- a/src/main/java/com/github/crashdemons/displayitem_spigot/DisplayItem.java
+++ b/src/main/java/com/github/crashdemons/displayitem_spigot/DisplayItem.java
@@ -111,6 +111,7 @@ public class DisplayItem extends JavaPlugin{
                 return true;
             }
             shareItem(player,target);//share with user
+            sender.sendMessage(ChatColor.GRAY+""+ChatColor.ITALIC+"*You shared your item with "+ChatColor.WHITE+targetUser+ChatColor.GRAY+".");
         }
         if(willPublish){
             if(!canPublish){

--- a/src/main/java/com/github/crashdemons/displayitem_spigot/DisplayItem.java
+++ b/src/main/java/com/github/crashdemons/displayitem_spigot/DisplayItem.java
@@ -76,7 +76,7 @@ public class DisplayItem extends JavaPlugin{
     
     private boolean onCommandShare(CommandSender sender, Command cmd, String label, String[] args){
         if(args.length>1) return false;
-        if (sender.hasPermission("displayitem.share")){ 
+        if (!sender.hasPermission("displayitem.share")){ 
             sender.sendMessage(ChatColor.RED+"You don't have permission to use this command.");
             return true;
         }
@@ -107,7 +107,7 @@ public class DisplayItem extends JavaPlugin{
             String targetUser = args[0];
             Player target = Bukkit.getPlayer(targetUser);
             if (target==null){ 
-                sender.sendMessage(ChatColor.RED+"Can't find a user with the name '"+target+"' online.");
+                sender.sendMessage(ChatColor.RED+"Can't find the user '"+targetUser+"' online.");
                 return true;
             }
             shareItem(player,target);//share with user
@@ -160,6 +160,7 @@ public class DisplayItem extends JavaPlugin{
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
         if (cmd.getName().equalsIgnoreCase("displayitem")) return onCommandReload(sender, cmd, label, args);
         if (cmd.getName().equalsIgnoreCase("displayitemcalibrate")) return onCommandCalibrate(sender, cmd, label, args);
+        if (cmd.getName().equalsIgnoreCase("displayitemshare")) return onCommandShare(sender, cmd, label, args);
 
         return true;
     }

--- a/src/main/java/com/github/crashdemons/displayitem_spigot/MacroReplacements.java
+++ b/src/main/java/com/github/crashdemons/displayitem_spigot/MacroReplacements.java
@@ -56,7 +56,9 @@ public class MacroReplacements {
         "repaircost",
         "repaircostE",
         "Rrepaircost",
-    
+        
+        "replacement",
+        "metareplacement",
     
     };
     private static final String[] paddingSuffixes = new String[]{
@@ -446,6 +448,10 @@ public class MacroReplacements {
                 int rcr = getRepairCost(meta);
                 if(rcr<0) return "";
                 return "RC:"+rcr;
+            case "replacement":
+                return DisplayItem.plugin.getConfig().getString("displayitem.replacement");
+            case "metareplacement":
+                return DisplayItem.plugin.getConfig().getString("displayitem.metareplacement");
             default:
                 return null;
         }

--- a/src/main/java/com/github/crashdemons/displayitem_spigot/MessageFormatter.java
+++ b/src/main/java/com/github/crashdemons/displayitem_spigot/MessageFormatter.java
@@ -20,6 +20,8 @@ import org.bukkit.inventory.ItemStack;
  */
 public class MessageFormatter{
 
+    //todo: static?
+    
     private BaseComponent[] formatItemComponents(Player player, ItemStack item, boolean colorize){
         String itemformat = ChatColor.translateAlternateColorCodes('&', DisplayItem.plugin.getConfig().getString("displayitem.itemformat"));
         boolean usebookname = DisplayItem.plugin.getConfig().getBoolean("displayitem.usebooknameformat");

--- a/src/main/java/com/github/crashdemons/displayitem_spigot/MessageFormatter.java
+++ b/src/main/java/com/github/crashdemons/displayitem_spigot/MessageFormatter.java
@@ -22,7 +22,7 @@ public class MessageFormatter{
 
     //todo: static?
     
-    private BaseComponent[] formatItemComponents(Player player, ItemStack item, boolean colorize){
+    private static BaseComponent[] formatItemComponents(Player player, ItemStack item, boolean colorize){
         String itemformat = ChatColor.translateAlternateColorCodes('&', DisplayItem.plugin.getConfig().getString("displayitem.itemformat"));
         boolean usebookname = DisplayItem.plugin.getConfig().getBoolean("displayitem.usebooknameformat");
         String bookformat = ChatColor.translateAlternateColorCodes('&', DisplayItem.plugin.getConfig().getString("displayitem.booknameformat"));
@@ -54,7 +54,7 @@ public class MessageFormatter{
         return itemComponent;
     }
     
-    public SplitChatMessage messageInsertItem(Player player, String messageText, boolean colorize){
+    public static SplitChatMessage messageInsertItem(Player player, String messageText, boolean colorize){
         String metareplacestr = DisplayItem.plugin.getConfig().getString("displayitem.metareplacement");
         String replacestr = DisplayItem.plugin.getConfig().getString("displayitem.replacement");
         SplitChatMessage bukkitTextSplit = SplitChatMessage.fromWithExternalReplacement(messageText, replacestr,   metareplacestr,replacestr);

--- a/src/main/java/com/github/crashdemons/displayitem_spigot/TextUtils.java
+++ b/src/main/java/com/github/crashdemons/displayitem_spigot/TextUtils.java
@@ -16,7 +16,7 @@ public class TextUtils {
     private TextUtils(){}
     public static String toLegacyText(BaseComponent[] components, boolean format){
         String legacyMessage = "";
-        for(BaseComponent component : components){
+        for(BaseComponent component : components){ //TODO; consider putting in a nested BaseComponent for conversion.
             legacyMessage+=component.toLegacyText();
         }
         if(!format) return ChatColor.stripColor(legacyMessage);

--- a/src/main/java/com/github/crashdemons/displayitem_spigot/events/ShareChatEvent.java
+++ b/src/main/java/com/github/crashdemons/displayitem_spigot/events/ShareChatEvent.java
@@ -1,0 +1,43 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.github.crashdemons.displayitem_spigot.events;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+/**
+ *
+ * @author crashdemons (crashenator at gmail.com)
+ */
+public class ShareChatEvent implements ChatEvent {
+    Set<Player> recipients;
+    Player player;
+    String format;
+    String message;
+    
+    public ShareChatEvent(Player sender, String format, String message, Set<Player> recipients){
+        this.player=sender;
+        this.format=format;
+        this.message=message;
+        this.recipients=recipients;
+    }
+    
+    public ShareChatEvent(Player sender, String format, String message, Player recipient){
+        this(sender,format,message,new HashSet<>(Collections.singleton(recipient)));
+    }
+    
+    public ShareChatEvent(Player sender, String format, String message){
+        this(sender,format,message,new HashSet<>(ImmutableList.copyOf(Bukkit.getOnlinePlayers())));
+    }
+    
+    public boolean isAsynchronous(){
+        return false;
+    }
+}

--- a/src/main/java/com/github/crashdemons/displayitem_spigot/events/ShareChatEvent.java
+++ b/src/main/java/com/github/crashdemons/displayitem_spigot/events/ShareChatEvent.java
@@ -21,6 +21,7 @@ public class ShareChatEvent implements ChatEvent {
     Player player;
     String format;
     String message;
+    boolean cancelled;
     
     public ShareChatEvent(Player sender, String format, String message, Set<Player> recipients){
         this.player=sender;
@@ -37,7 +38,32 @@ public class ShareChatEvent implements ChatEvent {
         this(sender,format,message,new HashSet<>(ImmutableList.copyOf(Bukkit.getOnlinePlayers())));
     }
     
-    public boolean isAsynchronous(){
+    public Player getPlayer(){
+        return player;
+    }
+    public String getFormat(){
+        return format;
+    }
+    public String getMessage(){
+        return message;
+    }
+    public Set<Player> getRecipients(){
+        return recipients;
+    }
+    public boolean isCancelled(){
+        return cancelled;
+    }
+    public void setCancelled​(boolean cancel){
+        cancelled=cancel;
+    }
+    public void setFormat​(String format){
+        this.format=format;
+    }
+    public void setMessage​(String message){
+        this.message=message;
+    }
+    public boolean isAsynchronous(){//TODO: verify? allow configuring it?
         return false;
     }
+    
 }

--- a/src/main/java/com/github/crashdemons/displayitem_spigot/events/ShareCommandEvent.java
+++ b/src/main/java/com/github/crashdemons/displayitem_spigot/events/ShareCommandEvent.java
@@ -5,6 +5,8 @@
  */
 package com.github.crashdemons.displayitem_spigot.events;
 
+import com.github.crashdemons.displayitem_spigot.DisplayItem;
+import com.github.crashdemons.displayitem_spigot.MacroReplacements;
 import com.google.common.collect.ImmutableList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -16,26 +18,32 @@ import org.bukkit.entity.Player;
  *
  * @author crashdemons (crashenator at gmail.com)
  */
-public class ShareChatEvent implements ChatEvent {
+public class ShareCommandEvent implements ChatEvent {
     Set<Player> recipients;
     Player player;
     String format;
     String message;
     boolean cancelled;
     
-    public ShareChatEvent(Player sender, String format, String message, Set<Player> recipients){
+    public ShareCommandEvent(Player sender, Set<Player> recipients){
+        String format = DisplayItem.plugin.getConfig().getString("shareformatbukkit");
+        String message = DisplayItem.plugin.getConfig().getString("shareformatmessage");
+        format = MacroReplacements.replaceAll(player, format, "%2$s", "", false, -1, false);
+        message = MacroReplacements.replaceAll(player, message, "", "", false, -1, false);
+        
+        
         this.player=sender;
         this.format=format;
         this.message=message;
         this.recipients=recipients;
     }
     
-    public ShareChatEvent(Player sender, String format, String message, Player recipient){
-        this(sender,format,message,new HashSet<>(Collections.singleton(recipient)));
+    public ShareCommandEvent(Player sender, Player recipient){
+        this(sender,new HashSet<>(Collections.singleton(recipient)));
     }
     
-    public ShareChatEvent(Player sender, String format, String message){
-        this(sender,format,message,new HashSet<>(ImmutableList.copyOf(Bukkit.getOnlinePlayers())));
+    public ShareCommandEvent(Player sender){
+        this(sender,new HashSet<>(ImmutableList.copyOf(Bukkit.getOnlinePlayers())));
     }
     
     public Player getPlayer(){

--- a/src/main/java/com/github/crashdemons/displayitem_spigot/events/ShareCommandEvent.java
+++ b/src/main/java/com/github/crashdemons/displayitem_spigot/events/ShareCommandEvent.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
 /**
@@ -25,11 +26,17 @@ public class ShareCommandEvent implements ChatEvent {
     String message;
     boolean cancelled;
     
-    public ShareCommandEvent(Player sender, Set<Player> recipients){
-        String format = DisplayItem.plugin.getConfig().getString("shareformatbukkit");
-        String message = DisplayItem.plugin.getConfig().getString("shareformatmessage");
+    private static String getFormat(String name){
+        return DisplayItem.plugin.getConfig().getString("displayitem.shareformat"+name);
+    }
+    
+    
+    public ShareCommandEvent(Player sender, Set<Player> recipients, String format, String message){
+        //String format = DisplayItem.plugin.getConfig().getString("displayitem.shareformatbukkit");
+        //String message = DisplayItem.plugin.getConfig().getString("displayitem.shareformatmessage");
         format = MacroReplacements.replaceAll(player, format, "%2$s", "", false, -1, false);
         message = MacroReplacements.replaceAll(player, message, "", "", false, -1, false);
+        message = ChatColor.translateAlternateColorCodes('&', message);
         
         
         this.player=sender;
@@ -39,11 +46,11 @@ public class ShareCommandEvent implements ChatEvent {
     }
     
     public ShareCommandEvent(Player sender, Player recipient){
-        this(sender,new HashSet<>(Collections.singleton(recipient)));
+        this(sender,new HashSet<>(Collections.singleton(recipient)),getFormat("bukkitprivate"),getFormat("messageprivate"));
     }
     
     public ShareCommandEvent(Player sender){
-        this(sender,new HashSet<>(ImmutableList.copyOf(Bukkit.getOnlinePlayers())));
+        this(sender,new HashSet<>(ImmutableList.copyOf(Bukkit.getOnlinePlayers())),getFormat("bukkit"),getFormat("message"));
     }
     
     public Player getPlayer(){

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -27,6 +27,21 @@ displayitem:
     #how a users message sharing an item with /shareitem should appear
     #note that %replacement% should appear somewhere in the message if you want the item to appear at all.
     shareformatmessage: 'shared an item: %replacement%'
+    
+    
+
+    #how the message shared in chat should appear using bukkit format
+    #this is a String.format() compatible string where the username is %1$s and the message is %2$s
+    #note that 'overridechatformat' does not affect the share command format, so you must make changes here.
+    #note that 'displayitem.replace' permission does not apply to share command uses, it has its own permission.
+    #but displayitem.colorname permission does apply to share command appearance.
+    shareformatbukkitprivate: "&7&o*%1$s&r &7&o%2$s"
+    #how a users message sharing an item with /shareitem should appear
+    #note that %replacement% should appear somewhere in the message if you want the item to appear at all.
+    shareformatmessageprivate: 'shared an item with you: %replacement%'
+    
+    
+    
 
     #how many item-display records history to keep for detecting spam
     spamdetectionbuffer: 5

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -23,7 +23,7 @@ displayitem:
     #note that 'overridechatformat' does not affect the share command format, so you must make changes here.
     #note that 'displayitem.replace' permission does not apply to share command uses, it has its own permission.
     #but displayitem.colorname permission does apply to share command appearance.
-    shareformatbukkit: "*\%1$s %2$s"
+    shareformatbukkit: "*%1$s %2$s"
     #how a users message sharing an item with /shareitem should appear
     #note that %replacement% should appear somewhere in the message if you want the item to appear at all.
     shareformatmessage: 'shared an item: %replacement%'

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -17,6 +17,11 @@ displayitem:
     overridechatformat: false
     #how the chat message line should appear (using formatting codes and replacements)
     format: '&r%displayname%&f: %message%'
+    
+    #how a user sharing an item with /shareitem should appear
+    #note that %replacement% should appear somewhere in the message if you want the item to appear at all.
+    shareformatline: '*&r%displayname%&f %message%'
+    shareformatmessage: 'shared an item: %replacement%'
 
     #how many item-display records history to keep for detecting spam
     spamdetectionbuffer: 5

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -18,9 +18,14 @@ displayitem:
     #how the chat message line should appear (using formatting codes and replacements)
     format: '&r%displayname%&f: %message%'
     
-    #how a user sharing an item with /shareitem should appear
+    #how the message shared in chat should appear using bukkit format
+    #this is a String.format() compatible string where the username is %1$s and the message is %2$s
+    #note that 'overridechatformat' does not affect the share command format, so you must make changes here.
+    #note that 'displayitem.replace' permission does not apply to share command uses, it has its own permission.
+    #but displayitem.colorname permission does apply to share command appearance.
+    shareformatbukkit: "*\%1$s %2$s"
+    #how a users message sharing an item with /shareitem should appear
     #note that %replacement% should appear somewhere in the message if you want the item to appear at all.
-    shareformatline: '*&r%displayname%&f %message%'
     shareformatmessage: 'shared an item: %replacement%'
 
     #how many item-display records history to keep for detecting spam

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -23,6 +23,12 @@ commands:
         permission: displayitem.calibrate
         permission-message: You don't have permission for this command
         aliases: [dicalibrate,diset]
+    displayitemshare:
+        usage: /displayitemshare [user]
+        description: Shares an item
+        permission: displayitem.share
+        permission-message: You don't have permission for this command
+        aliases: [dishareitem,shareitem]
 
 #permissions supported by DisplayItem.
 #you should apply or negate/deny these with your permissions plugin (like LuckPerms/PEX) or your server's Permissions.yml.
@@ -51,6 +57,20 @@ permissions:
     displayitem.colorname:
         description: Controls whether the name of the item is colorized for this user's chat. Requires 'replace' permission
         default: true
+        
+    displayitem.share:
+        description: Controls access to the shareitem command
+        default: false 
+        
+    displayitem.share.all:
+        description: Controls access to the shareitem command sent to all users
+        default: false 
+        
+    displayitem.share.other:
+        description: Controls access to the shareitem command sent to other users
+        default: false 
+        
+        
         
     displayitem.bypasscooldown:
         description: Bypass the spam detection cooldown


### PR DESCRIPTION
adds a /shareitem command with specific permissions for each use-case.

allows sharing items in chat specifically with a command and a configurable appearance.
allows sharing items in private with another user with a command and a configurable appearance.

