### PR TITLE
Item minimizer - reduce number of tags on displayed items

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.crashdemons</groupId>
     <artifactId>DisplayItem-Spigot</artifactId>
-    <version>2.8.0-SNAPSHOT</version>
+    <version>2.9.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <properties>
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>

--- a/src/main/java/com/github/crashdemons/displayitem_spigot/ItemMinimizer.java
+++ b/src/main/java/com/github/crashdemons/displayitem_spigot/ItemMinimizer.java
@@ -5,19 +5,94 @@
  */
 package com.github.crashdemons.displayitem_spigot;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import org.bukkit.Material;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.ShulkerBox;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BlockStateMeta;
+import org.bukkit.inventory.meta.BookMeta;
+import org.bukkit.inventory.meta.ItemMeta;
 
 /**
  *
  * @author crashdemons (crashenator at gmail.com)
  */
 public class ItemMinimizer {
-    private ItemMinimizer(){}
-    
-    
-    public static ItemStack minimize(ItemStack stack){
-        ItemStack copiedItem = new ItemStack(stack);
-        
-        
+
+    private ItemMinimizer() {
     }
+
+    public static ItemStack minimize(ItemStack stack) {
+        if (stack == null) {
+            return null;
+        }
+        if (stack.getType() == Material.AIR || !stack.hasItemMeta()) {
+            return stack;
+        }
+
+        switch (stack.getType()) {
+            case WRITTEN_BOOK:
+            case WRITABLE_BOOK:
+                return minimizeBook(stack);
+            case SHULKER_BOX:
+                return minimizeShulker(stack);
+            default:
+                return stack;
+        }
+    }
+
+    private static ItemStack minimizeBook(ItemStack stack) {
+        ItemStack copiedStack = new ItemStack(stack);
+        ItemMeta meta = copiedStack.getItemMeta();
+        if (!(meta instanceof BookMeta)) {
+            return stack;
+        }
+        BookMeta book = (BookMeta) meta;
+        if (!book.hasPages()) {
+            return stack;
+        }
+
+        book.setPages(minimizeBookPages(book.getPages()));
+        copiedStack.setItemMeta(book);
+        
+
+        return copiedStack;
+    }
+
+    private static ItemStack minimizeShulker(ItemStack stack) {
+        ItemStack copiedItem = new ItemStack(stack);
+        ItemMeta meta = stack.getItemMeta();
+        if (!(meta instanceof BlockStateMeta)) {
+            return stack;
+        }
+        BlockStateMeta block = (BlockStateMeta) meta;
+        BlockState state = block.getBlockState();
+        if (!(state instanceof ShulkerBox)) {
+            return stack;
+        }
+
+        ShulkerBox box = (ShulkerBox) state;
+        Inventory inv = box.getInventory();
+                
+        inv = minimizeShulkerInventory(inv);
+        
+        block.setBlockState(state);
+        
+        copiedItem.setItemMeta(block);
+
+        return copiedItem;
+
+    }
+
+    private static List<String> minimizeBookPages(List<String> pages) {
+        return pages.stream().map((page) -> "").collect(Collectors.toList());
+    }
+
+    private static Inventory minimizeShulkerInventory(Inventory inv) {
+        return null;
+    }
+
 }

--- a/src/main/java/com/github/crashdemons/displayitem_spigot/ItemMinimizer.java
+++ b/src/main/java/com/github/crashdemons/displayitem_spigot/ItemMinimizer.java
@@ -5,8 +5,10 @@
  */
 package com.github.crashdemons.displayitem_spigot;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.ShulkerBox;
@@ -33,12 +35,13 @@ public class ItemMinimizer {
             return stack;
         }
 
+        if(stack.getType().name().toUpperCase().endsWith("SHULKER_BOX")) return minimizeShulker(stack);
+        
+        
         switch (stack.getType()) {
             case WRITTEN_BOOK:
             case WRITABLE_BOOK:
                 return minimizeBook(stack);
-            case SHULKER_BOX:
-                return minimizeShulker(stack);
             default:
                 return stack;
         }
@@ -91,8 +94,42 @@ public class ItemMinimizer {
         return pages.stream().map((page) -> "").collect(Collectors.toList());
     }
 
+    private static final int NUM_VISIBLE_SHULKER_ITEMS = 6;
+    private static final Material UNSEEN_ITEM_PLACEHOLDER = Material.ICE;
+    
     private static Inventory minimizeShulkerInventory(Inventory inv) {
-        return null;
+        
+        for(int i = 0 ; i < inv.getSize() ; i++) {
+            ItemStack item = inv.getItem(i);
+            
+            if(i<NUM_VISIBLE_SHULKER_ITEMS) item = minimizeNamedShulkerItem(item);
+            else item = minimizeUnseenShulkerItem(item);
+            
+            inv.setItem(i, item);
+        }
+        
+        
+        return inv;
     }
 
+    
+    private static ItemStack minimizeNamedShulkerItem(ItemStack stack){
+        if(stack==null) return stack;
+        if(stack.getType()==Material.AIR) return stack;
+        ItemStack replacement = new ItemStack(stack.getType());
+        replacement.setAmount(stack.getAmount());
+        
+        if(stack.hasItemMeta()){
+            ItemMeta replacementMeta = Bukkit.getItemFactory().getItemMeta(stack.getType());
+            ItemMeta oldMeta = stack.getItemMeta();
+            if(oldMeta.hasDisplayName()) replacementMeta.setDisplayName(oldMeta.getDisplayName());
+            replacement.setItemMeta(replacementMeta);
+        }
+        return replacement;
+    }
+    private static ItemStack minimizeUnseenShulkerItem(ItemStack stack){
+        ItemStack placeholder = new ItemStack(UNSEEN_ITEM_PLACEHOLDER);
+        placeholder.setAmount(stack.getAmount());
+        return placeholder;
+    }
 }

--- a/src/main/java/com/github/crashdemons/displayitem_spigot/ItemMinimizer.java
+++ b/src/main/java/com/github/crashdemons/displayitem_spigot/ItemMinimizer.java
@@ -115,7 +115,7 @@ public class ItemMinimizer {
     
     private static ItemStack minimizeNamedShulkerItem(ItemStack stack){//create a name-only copy of an item, if possible
         if(stack==null) return stack;
-        if(stack.getType()==Material.AIR) return stack;
+        if(stack.getType().isAir()) return stack;
         ItemStack replacement = new ItemStack(stack.getType());
         replacement.setAmount(stack.getAmount());
         
@@ -128,6 +128,8 @@ public class ItemMinimizer {
         return replacement;
     }
     private static ItemStack minimizeUnseenShulkerItem(ItemStack stack){//create a placeholder item with the same amount
+        if(stack==null) return stack;
+        if(stack.getType().isAir()) return stack;
         ItemStack placeholder = new ItemStack(UNSEEN_ITEM_PLACEHOLDER);
         placeholder.setAmount(stack.getAmount());
         return placeholder;

--- a/src/main/java/com/github/crashdemons/displayitem_spigot/ItemMinimizer.java
+++ b/src/main/java/com/github/crashdemons/displayitem_spigot/ItemMinimizer.java
@@ -90,7 +90,7 @@ public class ItemMinimizer {
 
     }
 
-    private static List<String> minimizeBookPages(List<String> pages) {
+    private static List<String> minimizeBookPages(List<String> pages) {//change all pages to blank
         return pages.stream().map((page) -> "").collect(Collectors.toList());
     }
 
@@ -102,8 +102,8 @@ public class ItemMinimizer {
         for(int i = 0 ; i < inv.getSize() ; i++) {
             ItemStack item = inv.getItem(i);
             
-            if(i<NUM_VISIBLE_SHULKER_ITEMS) item = minimizeNamedShulkerItem(item);
-            else item = minimizeUnseenShulkerItem(item);
+            if(i<NUM_VISIBLE_SHULKER_ITEMS) item = minimizeNamedShulkerItem(item);//replace any items seen on the hover list (6) with versions that are ONLY named
+            else item = minimizeUnseenShulkerItem(item);//replace any items in the box but not seen with placeholders
             
             inv.setItem(i, item);
         }
@@ -113,7 +113,7 @@ public class ItemMinimizer {
     }
 
     
-    private static ItemStack minimizeNamedShulkerItem(ItemStack stack){
+    private static ItemStack minimizeNamedShulkerItem(ItemStack stack){//create a name-only copy of an item, if possible
         if(stack==null) return stack;
         if(stack.getType()==Material.AIR) return stack;
         ItemStack replacement = new ItemStack(stack.getType());
@@ -127,7 +127,7 @@ public class ItemMinimizer {
         }
         return replacement;
     }
-    private static ItemStack minimizeUnseenShulkerItem(ItemStack stack){
+    private static ItemStack minimizeUnseenShulkerItem(ItemStack stack){//create a placeholder item with the same amount
         ItemStack placeholder = new ItemStack(UNSEEN_ITEM_PLACEHOLDER);
         placeholder.setAmount(stack.getAmount());
         return placeholder;

--- a/src/main/java/com/github/crashdemons/displayitem_spigot/ItemMinimizer.java
+++ b/src/main/java/com/github/crashdemons/displayitem_spigot/ItemMinimizer.java
@@ -1,0 +1,23 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.github.crashdemons.displayitem_spigot;
+
+import org.bukkit.inventory.ItemStack;
+
+/**
+ *
+ * @author crashdemons (crashenator at gmail.com)
+ */
+public class ItemMinimizer {
+    private ItemMinimizer(){}
+    
+    
+    public static ItemStack minimize(ItemStack stack){
+        ItemStack copiedItem = new ItemStack(stack);
+        
+        
+    }
+}

--- a/src/main/java/com/github/crashdemons/displayitem_spigot/chat/MessageFormatter.java
+++ b/src/main/java/com/github/crashdemons/displayitem_spigot/chat/MessageFormatter.java
@@ -7,10 +7,12 @@ package com.github.crashdemons.displayitem_spigot.chat;
 
 import com.github.crashdemons.displayitem_spigot.MacroReplacements;
 import com.github.crashdemons.displayitem_spigot.DisplayItem;
+import com.github.crashdemons.displayitem_spigot.ItemMinimizer;
 import com.sainttx.util.HoverComponentManager;
 import com.sainttx.util.ItemJsonLengthException;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -62,6 +64,10 @@ public class MessageFormatter{
         SplitChatMessage bukkitTextSplit = SplitChatMessage.fromWithExternalReplacement(messageText, replacestr,   metareplacestr,replacestr);
         
         ItemStack item = player.getInventory().getItemInMainHand();
+        
+        if(DisplayItem.plugin.getConfig().getBoolean("displayitem.minimize-items")) item = ItemMinimizer.minimize(item);
+                
+        
         BaseComponent[] itemComponent=formatItemComponents(player,item,colorize);
         
         bukkitTextSplit.content = itemComponent;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -50,6 +50,8 @@ displayitem:
     #sets whether a detected spam-post resets the spam timer (each failed post makes the user wait the full duration again) - prior to 2.4.2, the behavior of this was 'true'.
     spamdetectionsresetcooldown: false
     
+    #modify items posted in chat to contain less tags
+    minimize-items: true
     
     #sets an upper limit on the amount of JSON characters for the item to have a hover component
     jsonlimit: 8000


### PR DESCRIPTION
adds an item-minimizer routine that reduces the number of tags used by certain items (controlled by the `displayitem.minimize-items` config entry)

 * minimizes books by blanking all pages
 * minimizes shulkers by selectively minimizing items in the shulker:
   * creates items with the same name only for the first 6 (no lore, enchants, etc) [visible in the hover description]
   * replaces any unseen items with a placeholder (currently ice)